### PR TITLE
Update cpct_fw2hw_asmbindings.s

### DIFF
--- a/cpctelera/src/video/cpct_fw2hw_asmbindings.s
+++ b/cpctelera/src/video/cpct_fw2hw_asmbindings.s
@@ -22,6 +22,6 @@
 ;;
 ;; ASM bindings for <cpct_fw2hw>
 ;;
-cpct_fw2hw_asm:             ;; Assembly entry point 
+cpct_fw2hw_asm::             ;; Assembly entry point 
 
 .include /cpct_fw2hw.asm/


### PR DESCRIPTION
Solving scope issue on cpct_fw2hw_asm assembly entry point.
Original definition has just one colon instead of two, not beign global.